### PR TITLE
Feature/kk/projekte anzeigen

### DIFF
--- a/src/app/components/common/service/projektService/projektService.service.js
+++ b/src/app/components/common/service/projektService/projektService.service.js
@@ -13,7 +13,11 @@ class ProjektServiceService {
     }
 
     getProjektByID(projektId){
-        return this.Projekte.get({"projektId": projektId});
+      return this.Projekte.get({"projektId": projektId});
+    }
+
+    getProjektFromEndpoint(endpoint){
+      return this.$http.get(endpoint);
     }
 
     getProjektByEinsatz(einsatz){

--- a/src/app/components/mitarbeiterEinsatzGrid/mitarbeiterEinsatz.controller.js
+++ b/src/app/components/mitarbeiterEinsatzGrid/mitarbeiterEinsatz.controller.js
@@ -46,6 +46,11 @@ class MitarbeiterEinsatzController{
 
   _getProjekteForEinsatze(mitarbeiter, einsatze){
       let projektEinsaetze = [];
+
+      if(einsatze.length === 0){
+        this._createMitarbeiterEinsatz(mitarbeiter, einsatze);
+      }
+
       einsatze.forEach((einsatz) => {
         this.projektService.getProjektFromEndpoint(einsatz._links.projekt.href)
           .then((response) => {
@@ -54,7 +59,7 @@ class MitarbeiterEinsatzController{
               this._createMitarbeiterEinsatz(mitarbeiter, projektEinsaetze);
             }
           })
-      })
+      });
   }
 
   _createMitarbeiterEinsatz(mitarbeiter, projektEinsaetze){

--- a/src/app/components/mitarbeiterEinsatzGrid/mitarbeiterEinsatz.controller.js
+++ b/src/app/components/mitarbeiterEinsatzGrid/mitarbeiterEinsatz.controller.js
@@ -5,10 +5,12 @@ import createEinsatzTemplate from "./einsatzCreate/einsatzCreate.html";
 
 class MitarbeiterEinsatzController{
 
-  constructor(/*ngInject*/ mitarbeiterService, einsatzService, messagesService, $uibModal){
+  constructor(/*ngInject*/ mitarbeiterService, einsatzService, messagesService,
+    $uibModal, projektService){
     this.mitarbeiterService = mitarbeiterService;
     this.einsatzService = einsatzService;
     this.messagesService = messagesService;
+    this.projektService = projektService;
     this.$uibModal = $uibModal;
     this.mitarbeiter = [];
     this.year = parseInt(new Date().getFullYear());
@@ -33,7 +35,7 @@ class MitarbeiterEinsatzController{
       this.einsatzService.getEinsatzForMitarbeiter(mitarbeiter.uid)
         .$promise.then((response) => {
           let einsatze = response;
-          this._createMitarbeiterEinsatz(mitarbeiter, einsatze);
+          this._getProjekteForEinsatze(mitarbeiter, einsatze);
         },
         (error) => {
           this.messagesService.errorMessage('Ooops!! Etwas hat nicht funktioniert', false);
@@ -42,28 +44,44 @@ class MitarbeiterEinsatzController{
     })
   }
 
-  _createMitarbeiterEinsatz(mitarbeiter, einsatze){
-    let mitarbeiterEinsatze = this._convertEinsatze(einsatze);
+  _getProjekteForEinsatze(mitarbeiter, einsatze){
+      let projektEinsaetze = [];
+      console.log('OriginalEinsatz', einsatze);
+      einsatze.forEach((einsatz) => {
+        this.projektService.getProjektFromEndpoint(einsatz._links.projekt.href)
+          .then((response) => {
+            projektEinsaetze.push(this._convertToProjektEinsatz(einsatz, response.data));
+            if(projektEinsaetze.length === einsatze.length){
+              this._createMitarbeiterEinsatz(mitarbeiter, projektEinsaetze);
+            }
+          })
+      })
+  }
+
+  _createMitarbeiterEinsatz(mitarbeiter, projektEinsaetze){
+    let mitarbeiterEinsatze = this._convertProjektEinsaetze(projektEinsaetze);
     let einsatzSummary = {
       mitarbeiter: mitarbeiter,
       einsatze: mitarbeiterEinsatze,
     }
     this.mitarbeiterEinsaetze.push(einsatzSummary);
+    console.log('mitarbeiterEinsatze', this.mitarbeiterEinsaetze);
   }
 
-  _convertEinsatze(einsatze){
+  _convertProjektEinsaetze(projektEinsaetze){
     let mitarbeiterEinsatz = [];
-    einsatze.forEach((einsatz) => {
-      mitarbeiterEinsatz.push(this._convertEinsatz(einsatz));
+    projektEinsaetze.forEach((projektEinsatz) => {
+      mitarbeiterEinsatz.push(this._convertProjektEinsatz(projektEinsatz));
     });
     return mitarbeiterEinsatz;
   }
 
-  _convertEinsatz(einsatz){
+  _convertProjektEinsatz(projektEinsatz){
     return {
-      projekt: einsatz.projekt,
-      pensum: einsatz._embedded.pensen[0], //TODO kk: Müssen wir noch mehrere Einsätze unterstützen
-      senioritaet: einsatz.senioritaet
+      projekt: projektEinsatz.projekt,
+      pensum: projektEinsatz.einsatz._embedded.pensen[0], //TODO kk: Müssen wir noch mehrere Einsätze unterstützen
+      senioritaet: projektEinsatz.einsatz.senioritaet,
+      rolle: projektEinsatz.einsatz.rolle
     };
   }
 
@@ -101,12 +119,23 @@ class MitarbeiterEinsatzController{
           }
       })
       .result.then((newEinsatz) => {
-        this._addNewEinsatzToMitarbeiter(newEinsatz, index);
+        this.projektService.getProjektFromEndpoint(newEinsatz._links.projekt.href)
+          .then((response) => {
+            let projektEinsatz = this._convertToProjektEinsatz(newEinsatz, response.data);
+            this._addNewEinsatzToMitarbeiter(projektEinsatz, index);
+          });
       });
   }
 
+  _convertToProjektEinsatz(einsatz, projekt){
+    return {
+      einsatz: einsatz,
+      projekt: projekt
+    }
+  }
+
   _addNewEinsatzToMitarbeiter(newEinsatz, index){
-    let convertedEinsatz = this._convertEinsatz(newEinsatz);
+    let convertedEinsatz = this._convertProjektEinsatz(newEinsatz);
     this.mitarbeiterEinsaetze[index].einsatze.push(convertedEinsatz);
   }
 }

--- a/src/app/components/mitarbeiterEinsatzGrid/mitarbeiterEinsatz.controller.js
+++ b/src/app/components/mitarbeiterEinsatzGrid/mitarbeiterEinsatz.controller.js
@@ -46,7 +46,6 @@ class MitarbeiterEinsatzController{
 
   _getProjekteForEinsatze(mitarbeiter, einsatze){
       let projektEinsaetze = [];
-      console.log('OriginalEinsatz', einsatze);
       einsatze.forEach((einsatz) => {
         this.projektService.getProjektFromEndpoint(einsatz._links.projekt.href)
           .then((response) => {
@@ -65,7 +64,6 @@ class MitarbeiterEinsatzController{
       einsatze: mitarbeiterEinsatze,
     }
     this.mitarbeiterEinsaetze.push(einsatzSummary);
-    console.log('mitarbeiterEinsatze', this.mitarbeiterEinsaetze);
   }
 
   _convertProjektEinsaetze(projektEinsaetze){

--- a/src/app/components/mitarbeiterEinsatzGrid/mitarbeiterEinsatz.template.html
+++ b/src/app/components/mitarbeiterEinsatzGrid/mitarbeiterEinsatz.template.html
@@ -25,8 +25,8 @@
                   </a>
                 </td>
                 <td>
-                  <b>{{ mitarbeiterEinsatz.einsatze[0].projekt.name }}</b>
-                  {{ mitarbeiterEinsatz.einsatze[0].senioritaet }} {{ mitarbeiterEinsatz.einsatze[0].rolle }}
+                  <b>{{ mitarbeiterEinsatz.einsatze[0].projekt.name }}</b> als
+                  {{ mitarbeiterEinsatz.einsatze[0].senioritaet }} {{ mitarbeiterEinsatz.einsatze[0].rolle | uppercase }}
                 </td>
                 <td class="timeaxis-td">
                   <zeitachse selected-year="$ctrl.year" pensum="mitarbeiterEinsatz.einsatze[0].pensum"
@@ -37,8 +37,8 @@
               </tr>
               <tr ng-repeat-end ng-repeat="einsatz in mitarbeiterEinsatz.einsatze.slice(1)">
                 <td>
-                  <b>{{ einsatz.projekt.name }}</b>
-                  {{ einsatz.senioritaet }} {{ einsatz.rolle }}
+                  <b>{{ einsatz.projekt.name }}</b> als
+                  {{ einsatz.senioritaet }} {{ einsatz.rolle | uppercase }}
                 </td>
                 <td class="timeaxis-td">
                   <zeitachse selected-year="$ctrl.year" pensum="einsatz.pensum"

--- a/src/app/components/mitarbeiterEinsatzGrid/mitarbeiterEinsatz.template.html
+++ b/src/app/components/mitarbeiterEinsatzGrid/mitarbeiterEinsatz.template.html
@@ -25,7 +25,8 @@
                   </a>
                 </td>
                 <td>
-                  <b>{{ mitarbeiterEinsatz.einsatze[0].projekt.name }}</b> als
+                  <b>{{ mitarbeiterEinsatz.einsatze[0].projekt.name }}</b>
+                  <span ng-show="mitarbeiterEinsatz.einsatze[0].projekt.name && mitarbeiterEinsatz.einsatze[0].senioritaet">als</span>
                   {{ mitarbeiterEinsatz.einsatze[0].senioritaet }} {{ mitarbeiterEinsatz.einsatze[0].rolle | uppercase }}
                 </td>
                 <td class="timeaxis-td">
@@ -37,7 +38,8 @@
               </tr>
               <tr ng-repeat-end ng-repeat="einsatz in mitarbeiterEinsatz.einsatze.slice(1)">
                 <td>
-                  <b>{{ einsatz.projekt.name }}</b> als
+                  <b>{{ einsatz.projekt.name }}</b>
+                  <span ng-show="einsatz.projekt.name && einsatz.senioritaet">als</span>
                   {{ einsatz.senioritaet }} {{ einsatz.rolle | uppercase }}
                 </td>
                 <td class="timeaxis-td">

--- a/src/app/components/mitarbeiterEinsatzGrid/mitarbeiterEinsatz.template.html
+++ b/src/app/components/mitarbeiterEinsatzGrid/mitarbeiterEinsatz.template.html
@@ -21,7 +21,7 @@
                   <br />
                   <a href="" ng-click="$ctrl.createEinsatz(mitarbeiterEinsatz.mitarbeiter, $index)">
                       <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
-                      Einstaz erfassen
+                      Einsatz erfassen
                   </a>
                 </td>
                 <td>
@@ -33,7 +33,6 @@
                   <zeitachse selected-year="$ctrl.year" pensum="mitarbeiterEinsatz.einsatze[0].pensum"
                     row-index="outerIndex" ng-if="mitarbeiterEinsatz.einsatze[0].pensum"
                     ></zeitachse>
-                  </div>
                 </td>
               </tr>
               <tr ng-repeat-end ng-repeat="einsatz in mitarbeiterEinsatz.einsatze.slice(1)">


### PR DESCRIPTION
@surech In diesem Branch habe ich die Anzeige der Projekte umgesetzt. Zuerst hole ich mir die Mitarbeiter - für jeden Mitarbeiter dann die Einsätze - dann iteriere ich über die Einsätze und hole mir dann pro Einsatz das Projekt. All dies passiert asynchron und daher wird das Ganze ein wenig unübersichtlich.

Ich verstehe die Idee die Projekte nicht mit dem Einsatz herauszugeben um diese evtl. Clientseitig zu cashen und so die Datenmenge zu reduzieren. Bin mir aber nicht sicher ob sich das stark auf die Performance auswirkt - besonders da wir wahrscheinlich noch eine Pagination einbauen und pro Anfrage dann nur 20 Mitarbeiter mit den Projekten und nicht 200 herausgeben. Clientseitig würde es den Code übersichtlicher machen. 

Schau dir die Änderungen mal an - wenn das so passt dann können wir das so mergen und ich versuche anschliessend noch das Caching einzubauen. Andernfalls würden wir diesen PR ablehnen und im Backend noch Anpassungen machen und die Projekte nun doch mitgeben. 

Ich verstehe den Vorteil die Projekte separat anzufragen, sehe aber auch Vorteile sie embedded mit dem Einsatz herauszugeben