### PR TITLE
stu: Fehler bei Pensen ohne End-Datum beheben.

### DIFF
--- a/src/app/components/einsaetze/zeitachse/service/pensumConverter/pensumConverter.service.js
+++ b/src/app/components/einsaetze/zeitachse/service/pensumConverter/pensumConverter.service.js
@@ -18,8 +18,8 @@ export default class PensumConverter {
     }
     let fromYear = parseInt(pensum.anfang.substr(0, pensum.anfang.indexOf('-')));
     let startingDay = this._calculateDayOfYear(pensum.anfang);
-    let untilYear = parseInt(pensum.ende.substr(0, pensum.ende.indexOf('-')));
-    let endingDay = this._calculateDayOfYear(pensum.ende);
+    let untilYear = pensum.ende ? parseInt(pensum.ende.substr(0, pensum.ende.indexOf('-'))) : 2099;
+    let endingDay = pensum.ende ? this._calculateDayOfYear(pensum.ende) : 999999;
     let fromDate = this._convertDateStringToReadableDate(pensum.anfang);
     let untilDate = this._convertDateStringToReadableDate(pensum.ende);
 
@@ -35,6 +35,10 @@ export default class PensumConverter {
   }
 
   _convertDateStringToReadableDate(dateString){
+    if(!dateString){
+      return 'Unbestimmt';
+    }
+
     let timestamp = Date.parse(dateString);
     let date = new Date(timestamp);
 


### PR DESCRIPTION
@kreuzerk: Beim Darstellen von Pensen gab es noch immer einen Fehler. Dies habe ich mit diesem PR versucht zu beheben. Es ist vielleicht etwas mit der heissen Nadel gestrickt; du darfst es also gerne noch optimieren.